### PR TITLE
graphlib-backport 1.0.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,29 +11,35 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --use-deprecated=out-of-tree-build
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  skip: True  # [py<37]
 
 requirements:
   host:
     - pip
-    - python >=3.6,<4.0
-    - poetry
+    - python
+    - poetry 1.4.0
+    - setuptools
+    - wheel
   run:
-    - python >=3.6,<4.0
+    - python
 
 test:
   imports:
     - graphlib
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://pypi.org/project/graphlib-backport/
+  dev_url: https://github.com/mariushelf/graphlib_backport
+  doc_url: https://github.com/mariushelf/graphlib_backport
   summary: Backport of the Python 3.9 graphlib module for Python 3.6+
+  description: Backport of the Python 3.9 graphlib module for older Python versions.
   license: PSF-2.0
+  license_family: PSF
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
License: https://github.com/mariushelf/graphlib_backport/blob/master/LICENSE
Requirements: https://github.com/mariushelf/graphlib_backport/blob/master/pyproject.toml


Actions:
1. Apply an initial **percy** [patch](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/test_patch.json) and run locally a [script](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/updater_standalone.py) to: 
  - Remove `noarch python`
  - Skip `py<37`
  - Add flags `--no-deps --no-build-isolation` to `script`
  - Add missing `setuptools` and `wheel` to `host`
  - Fix `python` in `host` and `run`
2. Add `dev_url` and doc_url
3. Add `description`
4. Add license_family

Notes:
- `formulaic` https://github.com/AnacondaRecipes/formulaic-feedstock/blob/d669d6055b51a38bc1e0b7bcd4471e0e10cbc76a/recipe/meta.yaml#L27 requires it